### PR TITLE
Add log analyzer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Codex Project
+
+## Log Analyzer
+
+This repository includes a simple Python script to analyze system authentication logs for repeated failed SSH login attempts. The tool can help identify suspicious activity by summarizing how many times each IP address has failed to authenticate.
+
+### Usage
+
+1. Place or specify a log file, such as `/var/log/auth.log` or a custom log sample.
+2. Run the analyzer and optionally provide the path to your log file:
+
+```bash
+python log_analyzer.py /path/to/auth.log
+```
+
+The script outputs each IP address and the number of failed login attempts found in the log.

--- a/log_analyzer.py
+++ b/log_analyzer.py
@@ -1,0 +1,25 @@
+import re
+from collections import Counter
+import argparse
+
+LOG_FILE = "auth.log"  # default log file path
+FAILED_PATTERN = re.compile(r"Failed password for .* from (\d{1,3}(?:\.\d{1,3}){3})")
+
+def parse_failed_logins(path):
+    """Parse a log file and count failed SSH login attempts per IP."""
+    ips = []
+    with open(path) as f:
+        for line in f:
+            match = FAILED_PATTERN.search(line)
+            if match:
+                ips.append(match.group(1))
+    return Counter(ips)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Analyze failed SSH login attempts from a log file.")
+    parser.add_argument("logfile", nargs="?", default=LOG_FILE, help="Path to the log file (default: auth.log)")
+    args = parser.parse_args()
+
+    counts = parse_failed_logins(args.logfile)
+    for ip, num in counts.most_common():
+        print(f"{ip}: {num} failed attempts")


### PR DESCRIPTION
## Summary
- create `log_analyzer.py` to inspect authentication logs for failed logins
- document log analyzer purpose and usage

## Testing
- `python -m py_compile log_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_6847400512c883299a64a19b7c1268fa