### PR TITLE
Add simple Python CLI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # Codex Project
+
+A small Python command-line interface (CLI) built to showcase basic skills with
+[Click](https://click.palletsprojects.com/) and `requests`. Use it to greet
+someone or fetch data from the internet.
+
+## Features
+
+- `greet NAME` - display a personalized greeting
+- `fetch URL` - print the first part of a web page's content
+
+## Getting Started
+
+1. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the CLI
+
+```bash
+python -m codex.cli greet "World"
+python -m codex.cli fetch https://example.com --chars 200
+```
+
+Feel free to extend the tool with your own commands!
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+click>=8.0
+requests>=2.0

--- a/src/codex/__init__.py
+++ b/src/codex/__init__.py
@@ -1,0 +1,2 @@
+"""Codex CLI package."""
+__all__ = []

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -1,0 +1,35 @@
+import sys
+from typing import Optional
+
+import click
+import requests
+
+@click.group()
+def main():
+    """Codex command line interface."""
+
+
+@main.command()
+@click.argument("name")
+def greet(name: str):
+    """Greet NAME with a friendly message."""
+    click.echo(f"Hello, {name}! Welcome to the Codex CLI.")
+
+
+@main.command()
+@click.argument("url")
+@click.option("--chars", default=100, help="Number of characters to display from the response.")
+def fetch(url: str, chars: int):
+    """Fetch URL and print the first CHARS characters of the response."""
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        click.echo(f"Error fetching {url}: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(response.text[:chars])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add basic CLI example with click
- document features and usage in README
- include requirements.txt for dependencies

## Testing
- `python -m codex.cli greet "World"`
- `python -m codex.cli fetch https://example.com --chars 200`


------
https://chatgpt.com/codex/tasks/task_e_68474ced76dc8329901e8e22954e5b10